### PR TITLE
not super pleasant, but we deployed to raspi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ arbie:
 start:
 	@test -f db-backups/rclone/rclone.conf || (echo "Missing ReadyBot/db-backups/rclone.conf - check Readybot/README.md for details" && exit 1)
 	docker compose up --build -d
-	$(MAKE) run-migrations
+#	$(MAKE) run-migrations
 	$(MAKE) arbie
 
 # this will stop and wipe everything

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ BACKUPS
     - dbmate fucking hates running on the raspi. seems like no binaries work? and so its gotta be downloaded and compiled, which is insane. 
     - janky state: 
         - migrations ran, once, and then i ingested the data from shitgres into docker postgres
-        - back up was ran, i then wiped things, commented out the migrations line in `start`, ran the stack, deployed the backup, data seems to be there. i then 
+        - back up was ran, i then wiped things, commented out the migrations line in `start`, ran the stack, deployed the backup, data seems to be there.
 
 
     notably right now when you restore, the backup is downloaded to the machine where youre restoring to. idk if i care. but jsyk

--- a/README.md
+++ b/README.md
@@ -120,20 +120,7 @@ npm install
 ( cd api && npm install )
 ```
 
-### 4. install dbmate on linux:
-
-```
-# get it
-curl -fsSL https://github.com/amacneil/dbmate/releases/download/v1.16.0/dbmate-linux-amd64 -o dbmate
-
-# make it executable
-chmod +x dbmate
-
-# move that shit
-sudo mv dbmate /usr/local/bin/
-```
-
-### 5. setup rclone
+### 4. setup rclone
 ```
 # install it
 curl https://rclone.org/install.sh | sudo bash
@@ -154,6 +141,8 @@ rclone config
 # move the config so the db-backups service can use it
 cp ~/.config/rclone/rclone.conf ./db-backups/rclone/rclone.conf
 ```
+
+### end of setup 
 
 TODO: think about test vs dev vs prod. when i run this on my laptop i see:
 
@@ -209,6 +198,15 @@ BACKUPS
     - restore chosen backup ✅
     - winner
 
+    # notes from trying to deploy:
+    - dbmate fucking hates running on the raspi. seems like no binaries work? and so its gotta be downloaded and compiled, which is insane. 
+    - janky state: 
+        - migrations ran, once, and then i ingested the data from shitgres into docker postgres
+        - back up was ran, i then wiped things, commented out the migrations line in `start`, ran the stack, deployed the backup, data seems to be there. i then 
+
+
     notably right now when you restore, the backup is downloaded to the machine where youre restoring to. idk if i care. but jsyk
 
     # jasper hey plz add log.txt to the gitignore at the next possible time!
+
+    TODO: move everything in the `data` folder into postgres

--- a/migrations/Dockerfile
+++ b/migrations/Dockerfile
@@ -1,13 +1,24 @@
-FROM alpine
+FROM golang:1.23-bullseye AS builder
 
-# Install dbmate + postgres client for connecting
-RUN apk add --no-cache postgresql-client bash curl && \
-    curl -fsSL https://github.com/amacneil/dbmate/releases/latest/download/dbmate-linux-amd64 > /usr/local/bin/dbmate && \
-    chmod +x /usr/local/bin/dbmate
+# Get dbmate source and build it
+RUN git clone https://github.com/amacneil/dbmate.git /dbmate && \
+    cd /dbmate && \
+    go build -o /dbmate-built/dbmate .
 
+# Final runtime container
+FROM debian:bookworm-slim
 
-# Copy the migration entry script into the image
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends postgresql-client ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy the built dbmate binary
+COPY --from=builder /dbmate-built/dbmate /usr/local/bin/dbmate
+RUN chmod +x /usr/local/bin/dbmate && /usr/local/bin/dbmate --version
+
+# Copy migration script
 COPY migrate.sh /migrate.sh
 RUN chmod +x /migrate.sh
 
 ENTRYPOINT ["/migrate.sh"]
+


### PR DESCRIPTION
I deployed the new stuff to the raspi, and everything except migrations worked completely smoothly. 

MIGRATIONS however, were a huge pain in the ass because there seems to be no nice binary that works on my raspi. admittedly, I could probably look for a proper binary maybe one more time - its very possible i missed something. But, ultimately i got around the problem by updating the dockerfile to download the dbmate go source and compile it right there on the raspi. it took like 7 minutes. but the migration ran! and the database got into a shape that could fit the data, and I stuffed it in there. More notes in the readme. 

All together, my ass is clenched but I think we're in a good spot. 