### PR TITLE
Restores migrations cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ arbie:
 start:
 	@test -f db-backups/rclone/rclone.conf || (echo "Missing ReadyBot/db-backups/rclone.conf - check Readybot/README.md for details" && exit 1)
 	docker compose up --build -d
-#	$(MAKE) run-migrations
+	$(MAKE) run-migrations
 	$(MAKE) arbie
 
 # this will stop and wipe everything
@@ -31,6 +31,14 @@ nuke:
 
 # nuke and then start the containers
 start-with-nuke: nuke start
+
+# this is just here so I can press tab and auto-complete most of the target
+redeploy-service-:
+	echo "Redeploy a service by name, e.g. 'redeploy-service-api'"
+
+# Redeploy a specific service by name
+redeploy-service-%:
+	docker compose up --build -d $*
 
 # Run linter in the api directory using its own config
 lint-api:
@@ -64,7 +72,7 @@ run-migrations:
 
 # run the backup script in the db-backups container
 backup:
-	docker exec readybot-db-backups-1 /backup.sh --prod
+	docker exec readybot-db-backups-1 /backup.sh
 
 # Wipe and restore the database using the restore script
 restore-backup:
@@ -81,3 +89,9 @@ restore-backup:
 	else \
 		echo "❌ Aborted."; \
 	fi
+
+# test that the backup script works
+test-backup: # this is kinda jank. come back to unit tests... sooner the better
+	sudo mkdir -p /root/.config/rclone
+	sudo cp ~/.config/rclone/rclone.conf /root/.config/rclone/rclone.conf
+	sudo --preserve-env bash db-backups/test_backups.sh

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ db-backups-1  | ⚠️  Running in PROD mode with DB=readybase_dev
 
 which is silly.
 
+- would love a separate channel in discord for prod/dev
+
 ### possibly do dev purely in docker? could be cool and good exercise
 
 ### move everything in the `data` folder into postgres
@@ -187,8 +189,6 @@ cp ~/.config/rclone/rclone.conf ./db-backups/rclone/rclone.conf
 ```
 
 # Section for planning and next steps:
-- handle the "when you restore a backup the backup is downloaded and left on the machine" thing
-- fix migrations binary thing
 - From a higher level, I think next steps are to:
     - put shitbot into a service
     - pull shitbot logic out into api, have shitbot call api

--- a/db-backups/restore.sh
+++ b/db-backups/restore.sh
@@ -2,7 +2,10 @@
 
 set -e
 
-BASE_FOLDER="gdrive:readybot_backups/${POSTGRES_DB}"
+
+DB_NAME="${POSTGRES_DB:?Must set POSTGRES_DB}"
+
+BASE_FOLDER="gdrive:readybot_backups/${DB_NAME}"
 SHORT_TERM_FOLDER="$BASE_FOLDER/short_term"
 LONG_TERM_FOLDER="$BASE_FOLDER/long_term"
 
@@ -50,10 +53,10 @@ SELECTED=$(sed -n "${SELECTED_INDEX}p" /tmp/numbered_combined.txt)
 
 # Download from GDrive
 echo "⬇️  Downloading '$BASE_FOLDER/$SELECTED'..."
-rclone copy "$BASE_FOLDER/$SELECTED" /backups
+rclone copy "$BASE_FOLDER/$SELECTED" "/backups/$DB_NAME"
 
 BASENAME=$(basename "$SELECTED")
-LOCAL_PATH="/backups/$BASENAME"
+LOCAL_PATH="/backups/$DB_NAME/$BASENAME"
 
 # Decompress if needed
 if echo "$BASENAME" | grep -qE '\.gz$$'; then

--- a/db-backups/test_backups.sh
+++ b/db-backups/test_backups.sh
@@ -41,7 +41,7 @@ done
 # === Run pruning/promoting logic ===
 
 echo "Running backup logic in test mode..."
-bash "$(dirname "$0")/backup.sh"
+bash "$(dirname "$0")/backup.sh" --test "$TEST_DB"
 
 # === Validate outcomes ===
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     depends_on:
       - postgres
     restart: always
-    entrypoint: ["sh", "-c", "while true; do /backup.sh --prod; sleep 86400; done"]
+    entrypoint: ["sh", "-c", "while true; do /backup.sh; sleep 86400; done"]
   migrations:
     build: ./migrations
     profiles:

--- a/template.env
+++ b/template.env
@@ -12,7 +12,7 @@ DB_PORT=5432
 # like. you can change the values, but not the names
 POSTGRES_USER=admin
 POSTGRES_PASSWORD=
-POSTGRES_DB=readybase
+POSTGRES_DB=
 DB_HOST=postgres
 
 # user that the api or whatever will use
@@ -28,6 +28,12 @@ DISCORD_BOT_CLIENT_ID=
 DISCORD_BOT_CLIENT_SECRET=
 DISCORD_BOT_TOKEN=
 
+# Channel where the ballots will be sent
+DISCORD_CONTROL_CHANNEL_ID=
+
 # Spotify credentials
 SPOTIFY_CLIENT_ID=
 SPOTIFY_CLIENT_SECRET=
+
+# My user id
+SPOTIFY_USER_ID=


### PR DESCRIPTION
So migrations on the raspi are weird because theres no nice binary that
seems to work on my raspi out of the gate. and so previously, I made it
so that we literally download the dbmate source and compile it ourselves
whenevere we run migrations. Which seemed to be a lot. (on the raspi
this takes like 7 minutes). I set out here to change that/make it not
take 7 minutes every time I want to run migrations on the raspi.
However, I've realized that docker automatically does some caching
stuff, and so it will build the binary only if theres been a change in
the dockerfile or if the dbmate repo is updated. I checked the repo, and
it seems like they only update the repo maybe once or twice a month, and
so I've decided that its just fine as is. Good enough, so to speak.

Backups and restores have been tweaked a bit. Instead of passing in a
--prod flag to indicate we're doing a prod backup, we pass in a --test
flag to indicate we're doing a test. My reasoning here is that I
sometimes do backups in my dev environment, and doing --prod to do those
backups doesn't make sense.

Also, restoring a backup now downloads the backup into the backups
folder for that particular db, meaning that they'll get cleaned up with
the regular local backups. Good enough for me.

I threw in a make target for running the backup tests, because I
would hate to forget they exist and then mess around with backups and
then oopsie they're broken

I also threw in a make target to redeploy a service. because that's
nice to have.

I tore out a bunch of dead code from the shitbot, and the shitbot now
pulls all env vars from the .env rather than from the
data/config.json or whatever. because that was weird and gross and bad.