### PR TITLE
Unit Tests For GET /scores

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -29,8 +29,10 @@ jobs:
     env:
       DB_HOST: localhost
       DB_PORT: 5432
-      API_POSTGRES_USER: user
-      API_POSTGRES_PASSWORD: password
+      POSTGRES_USER: user         # used by tests directly on db
+      POSTGRES_PASSWORD: password # used by tests directly on db
+      API_POSTGRES_USER: user         # used by the api
+      API_POSTGRES_PASSWORD: password # used by the api
       POSTGRES_DB: test_db
       DATABASE_URL: postgres://user:password@localhost:5432/test_db?sslmode=disable
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,22 @@
                 "<node_internals>/**",
                 "node_modules/**"
             ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug Unit Tests API",
+            "preLaunchTask": "prep-unit-tests-api",
+            "cwd": "${workspaceFolder}/api",
+            "program": "${workspaceFolder}/api/node_modules/jest/bin/jest.js",
+            "args": ["--runInBand"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "envFile": "${workspaceFolder}/.env",
+            "env": {
+                "DB_HOST": "localhost"
+            },
+            "runtimeArgs": ["--enable-source-maps"]
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,10 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "prep-unit-tests-api",
+      "type": "shell",
+      "command": "make prep-unit-tests-api"
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,14 @@ restore-backup:
 # 	sudo cp ~/.config/rclone/rclone.conf /root/.config/rclone/rclone.conf
 # 	sudo --preserve-env bash db-backups/test_backups.sh
 
-# DB_HOST must be set to localhost because the api tests run outside of docker
-test-api:
+# This gets things ready for running api tests
+# this is called by the test-api target, and also by the vscode debugger when debugging tests
+prep-unit-tests-api: 
 	docker compose down
 	docker compose up --build -d postgres
+	$(MAKE) run-migrations
+
+# DB_HOST must be set to localhost because the api tests run outside of docker
+unit-tests-api:
+	$(MAKE) prep-unit-tests-api
 	cd api && DB_HOST=localhost && npm test

--- a/README.md
+++ b/README.md
@@ -224,19 +224,18 @@ which is silly.
 - postgres health check in regular docker like in ci/cd ?
 - fix or delete `make test-backup`
 - api token auth
-- api: tidy what exists in the server tests
 - api: rest of endpoints
-- api: finish tests for GET /scores
 - api debug port is not passed around everywhere. make it so.
 - api index "port must be set"
 - api test code coverage trackers?
 - api endpoint docs swagger (?)
 - explore webhooks 
 - make sure integration tests vs unit tests are explained in readme properly
-- local api tests postgres doesnt do migrations. its empty. need to change that. 
 - from server.ts:
-// TODO(jruth): make linter require types?
-// TODO(jruth): check if .husky in the root folder is used/needed
+    - TODO(jruth): make linter require types?
+    - TODO(jruth): check if .husky in the root folder is used/needed
+- would be nice to add a pre commit to prevent committing to main branch
+- add types to the return values of createServer
 
 
 # Pull Request Merge Process

--- a/api/jest.config.ts
+++ b/api/jest.config.ts
@@ -1,14 +1,12 @@
-import { JestConfigWithTsJest } from 'ts-jest';
+import type { JestConfigWithTsJest } from 'ts-jest';
 
 const config: JestConfigWithTsJest = {
-  preset: 'ts-jest/presets/default-esm',
+  preset: 'ts-jest',
   testEnvironment: 'node',
-  extensionsToTreatAsEsm: ['.ts'],
-  globals: {
-    'ts-jest': {
-      useESM: true,
-    },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.jest.json' }],
   },
+  maxWorkers: 1,
 };
 
 export default config;

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "date-fns": "^4.1.0",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "pg": "^8.16.3"
@@ -29,7 +30,7 @@
         "lint-staged": "^16.1.2",
         "prettier": "^3.6.1",
         "supertest": "^7.1.4",
-        "ts-jest": "^29.4.4",
+        "ts-jest": "^29.4.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       }
@@ -821,10 +822,11 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1137,10 +1139,11 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -2955,6 +2958,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -4590,10 +4603,11 @@
       }
     },
     "node_modules/jest-config/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -4881,10 +4895,11 @@
       }
     },
     "node_modules/jest-runtime/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -5074,10 +5089,11 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -6337,10 +6353,11 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6909,9 +6926,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.4.tgz",
-      "integrity": "sha512-ccVcRABct5ZELCT5U0+DZwkXMCcOCLi2doHRrKy1nK/s7J7bch6TzJMsrY09WxgUUIP/ITfmcDS8D2yl63rnXw==",
+      "version": "29.4.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.5.tgz",
+      "integrity": "sha512-HO3GyiWn2qvTQA4kTgjDcXiMwYQt68a1Y8+JuLRVpdIzm+UOLSHgl/XqR4c6nzJkq5rOkjc02O2I7P7l/Yof0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6921,7 +6938,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.2",
+        "semver": "^7.7.3",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },

--- a/api/package.json
+++ b/api/package.json
@@ -23,6 +23,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "date-fns": "^4.1.0",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "pg": "^8.16.3"
@@ -43,7 +44,7 @@
     "lint-staged": "^16.1.2",
     "prettier": "^3.6.1",
     "supertest": "^7.1.4",
-    "ts-jest": "^29.4.4",
+    "ts-jest": "^29.4.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   }

--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -1,24 +1,43 @@
 import request from 'supertest';
 import { createServer } from './server';
-// import { Pool } from 'pg';
+import { Pool } from 'pg';
+import Express from 'express';
 
-// this is the postgres client
-// const pool = new Pool({
-//   host: process.env.DB_HOST,
-//   port: Number(process.env.DB_PORT),
-//   user: process.env.POSTGRES_USER,
-//   password: process.env.POSTGRES_PASSWORD,
-//   database: process.env.POSTGRES_DB,
-// });
+// all tests will use this emoji as the themoji
+const testThemoji = '🧪';
+const testThemoji2 = '✂';
+
+let pool: Pool;
+let server: Express.Application;
+let close: () => Promise<void>;
+
+beforeAll(async () => {
+  // postgres client used for direct db manipulation in tests
+  pool = new Pool({
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT),
+    user: process.env.POSTGRES_USER,
+    password: process.env.POSTGRES_PASSWORD,
+    database: process.env.POSTGRES_DB,
+  });
+
+  // the server used for testing
+  ({ server, close } = createServer());
+
+  // wipe scores for the test themoji
+  await pool.query(`DELETE FROM scores WHERE themoji = '${testThemoji}';`);
+  await pool.query(`DELETE FROM scores WHERE themoji = '${testThemoji2}';`);
+});
+
+afterAll(async () => {
+  await pool.end();
+  await close();
+});
 
 describe('GET /hello', () => {
   it('returns 200 OK', async () => {
-    const { server, close } = createServer();
-
     const res = await request(server).get('/hello');
     expect(res.status).toBe(200);
-
-    await close();
   });
 });
 
@@ -26,53 +45,144 @@ describe('GET /hello', () => {
 describe('GET /scores', () => {
   // try to get a score from the db when theres no pair
   it('returns 0 when there is no pair', async () => {
-    const { server, close } = createServer();
+    const res = await request(server).get(
+      `/scores?uri=testuri&themoji=${testThemoji}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      totalScore: 0,
+      intervalScore: 0,
+    });
+  });
 
-    const res = await request(server).get('/scores/?uri=testuri&themoji=🧪');
+  // check that the score is there
+  it('returns properly when accessing a score that is there and in interval', async () => {
+    // add a score to the scores table
+    await pool.query(
+      `INSERT INTO scores (spotify_uri, score, song_name, stamp, themoji) 
+        VALUES ('testuri', 1, 'Test Song', NOW(), '${testThemoji}')`
+    );
+
+    // request the score
+    const res = await request(server).get(
+      `/scores?uri=testuri&themoji=${testThemoji}&interval=5+seconds`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      totalScore: 1,
+      intervalScore: 1,
+    });
+  });
+
+  it('returns 0 for interval score when outside interval', async () => {
+    // sleep 2 seconds to ensure timestamp is outside interval
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // request with 1 second interval
+    const res = await request(server).get(
+      `/scores?uri=testuri&themoji=${testThemoji}&interval=1 second`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      totalScore: 1,
+      intervalScore: 0,
+    });
+  });
+
+  it('calculates totals correctly with multiple records, inside interval', async () => {
+    // add another score to the scores table
+    await pool.query(
+      `INSERT INTO scores (spotify_uri, score, song_name, stamp, themoji) 
+        VALUES ('testuri', 1, 'Test Song', NOW(), '${testThemoji}')`
+    );
+
+    // request the score with 5 second interval
+    const res = await request(server).get(
+      `/scores?uri=testuri&themoji=${testThemoji}&interval=5 seconds`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      totalScore: 2,
+      intervalScore: 2,
+    });
+  });
+
+  it('calculates totals correctly with multiple records, some inside and some outside interval', async () => {
+    // request the scores with 1 second interval
+    const res = await request(server).get(
+      `/scores?uri=testuri&themoji=${testThemoji}&interval=1 seconds`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      totalScore: 2,
+      intervalScore: 1,
+    });
+  });
+
+  it('calculates totals correctly with multiple records, all outside interval', async () => {
+    // request the scores with 1 second interval
+    const res = await request(server).get(
+      `/scores?uri=testuri&themoji=${testThemoji}&interval=1 millisecond`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      totalScore: 2,
+      intervalScore: 0,
+    });
+  });
+
+  it('calculates totals correctly with multiple records, no interval', async () => {
+    // request the scores with 1 second interval
+    const res = await request(server).get(
+      `/scores?uri=testuri&themoji=${testThemoji}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      totalScore: 2,
+      intervalScore: 2,
+    });
+  });
+
+  it('treats different themojis separately', async () => {
+    // request the score for a different themoji
+    const res = await request(server).get(
+      `/scores?uri=testuri&themoji=${testThemoji2}`
+    );
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       totalScore: 0,
       intervalScore: 0,
     });
 
-    await close();
+    // add a score with the different themoji
+    await pool.query(
+      `INSERT INTO scores (spotify_uri, score, song_name, stamp, themoji) 
+        VALUES ('testuri', 1, 'Test Song', NOW(), '${testThemoji2}')`
+    );
+
+    // request the score again
+    const res2 = await request(server).get(
+      `/scores?uri=testuri&themoji=${testThemoji2}`
+    );
+    expect(res2.status).toBe(200);
+    expect(res2.body).toEqual({
+      totalScore: 1,
+      intervalScore: 1,
+    });
   });
 
-  // // make a themoji pair
-  // // try to get a score from the db when theres a pair for a song that doesnt exist
-  // it('returns empty when there is a pair but no score', async () => {
-  //   // Directly insert a themoji pair
-  //   await pool.query(
-  //     'INSERT INTO themoji_pairs (song_id, themoji) VALUES ($1, $2)',
-  //     ['abc123', '🔥']
-  //   );
+  it('fails when interval is invalid', async () => {
+    const res = await request(server).get(
+      `/scores?uri=testuri&themoji=${testThemoji}&interval=invalidinterval`
+    );
+    expect(res.status).toBe(500);
+  });
 
-  //   const res = await request(server).get('/scores/abc123');
-  //   expect(res.status).toBe(200);
-  //   expect(res.body).toEqual([]);
-  // });
+  it('fails when required params are missing', async () => {
+    const res = await request(server).get(`/scores?themoji=${testThemoji}`);
+    expect(res.status).toBe(400);
 
-  // // add a score to the db themoji
-  // // check that the score is there
-  // it('returns empty when there is a pair but no score', async () => {
-  // });
+    const res2 = await request(server).get(`/scores?uri=testuri`);
+    expect(res2.status).toBe(400);
+  });
 });
-
-// put in a score via direct db access
-
-// then get it via the api
-
-// test get scores
-// test uri, themoji, interval
-// uri not found
-// themoji not found
-// interval invalid (?)
-// test you can see it with no interval (all time)
-// test you can see it with an interval
-// test that you can't see it with a too small interval
-// test that multiple score records are summed correctly
-// test no rows
-// test bad input -> 400
-// test invalid input -> 400
-// try same song with different emojis (should be different scores)
-// sql injection

--- a/api/tsconfig.jest.json
+++ b/api/tsconfig.jest.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "inlineSourceMap": true,
+    "inlineSources": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/shitbot/main.js
+++ b/shitbot/main.js
@@ -336,7 +336,7 @@ var bot = {
 
     logScore: function (uri, name, emoji, score) {
         return new Promise((resolve, reject) => {
-            let queryStatement = `INSERT INTO scores (spotify_uri, score, song_name, stamp, themoji) VALUES ('${uri}', '${score}', '${name.replace(/'/g, "''")}', '${format(new Date(), "yyyy-MM-dd HH:mm:ss.SSS")}', '${emoji}')`;
+            let queryStatement = `INSERT INTO scores (spotify_uri, score, song_name, stamp, themoji) VALUES ('${uri}', '${score}', '${name.replace(/'/g, "''")}', NOW(), '${emoji}')`;
             bot.ensureSongIsInBarrel(uri, name)
                 .then(() => this.query(queryStatement))
                 .then((results) => bot.getSongScores(uri, name, emoji))


### PR DESCRIPTION
Some unit test dev logistics/tools:
- When you run unit tests locally, migrations are now ran on the db
- CI/CD now has env vars for POSTGRES_USER and POSTGRES_PASSWORD, this
  is so tests can access the db directly
- Added a launch config for debugging unit tests in the vscode debugger
	- split out the make target for `make unit-tests-api` into a prep target
and a target that preps and runs tests. This is so the debugger can
call the prep target before initializing unit tests in debug. The idea here is
that this way the two ways of prepping for unit tests (debug and non-debug) stay
in sync. it would suck to update unit tests one way, and have them not work in
the other.
	- Updated a bunch of jest config shenanigans so that the
	  debugger can map ts files to the compiled js files, and vice
versa
- NOTE: i've configured tests to run on one worker so that these tests
  run sequentially. I can imagine a future where we mess with that to
get some tests running in parallel, but I didn't want to shake that boat
in this pr.

Tidied+finished unit tests for GET /scores:
- Tests for existing uris, nonexisting uris, aggregate scores within,
  across, and outside of intervals, and that scores with different themojis are in
fact aggregated separately correctly
- Tests for bad inputs
	- uri & themoji are required (400 if missing)
	- interval is optional, defaults to 618 years if not supplied,
	  and 500's if supplied interval is invalid

Tweaked the actual GET /scores endpoint:
- Updated the comment - eventually i hope to standardize the
  documentation of these endpoints, and have like swagger or something.
But for now this will do.
- We were checking for if (result.rows.length === 0), but because we're
  aggregating scores into two totals (interval and total), there will
always be exactly two rows. So i removed the check entirely.
- We weren't converting the score numbers from the string result to
  numbers, now we are.

Additionally, updated the score insertion code to use postgres's NOW()
rather than generating a now and plugging it in. this should avoid weird
timezone things. because the only one generating a time is postgres.

Finally, you may notice the commit history is a bit bungled. this is because, as
jasper-rutherford, I have supreme power in this repo, and main's branch
protection rule cannot stop me, and i accidentally pushed a bunch of changes
straight on to main. tut tut. i've since changed the settings such that I can no
longer bypass the rules. go team!