### PR TITLE
Tweaked Makefile and Readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ export
 .PHONY: arbie docker lint-api pretty-api clean-api postgres postgres-readybot run-migrations new-migration
 
 # 1. check that the rclone config exists
-# 2. run all the docker containers except the shitbot
+# 2. run all the docker containers except migrations and the shitbot 
 # 3. run migrations
 # 4. run the shitbot container
 start:
 	@test -f db-backups/rclone/rclone.conf || (echo "Missing ReadyBot/db-backups/rclone.conf - check Readybot/README.md for details" && exit 1)
-	docker compose up --build -d api postgres db-backups migrations
+	docker compose up --build -d api postgres db-backups
 	$(MAKE) run-migrations
 	docker compose up --build -d shitbot
 	@echo "If you aren't seeing the ballot messages, consider going to http://localhost:8888/login to authenticate spotify."
@@ -21,7 +21,8 @@ nuke:
 	@echo "⚠️  This will completely destroy your Postgres data."
 	@read -p "Are you sure you want to continue? Type 'yes' to confirm: " confirm && \
 	if [ "$$confirm" = "yes" ]; then \
-		docker compose down -v; \
+		docker compose down -v --remove-orphans; \
+		docker network prune -f; \
 	else \
 		echo "Aborted."; \
 	fi

--- a/README.md
+++ b/README.md
@@ -214,11 +214,6 @@ which is silly.
 
 - I want the shitbot service gone.
 
-- have a second discord bot, which is ReadyBot. this is where we will migrate/build good discord bot code into.
-- update existing shitbot to be a separate discord bot called "shitbot".
-
-- dev env should have two dev bots. name all 4 bots appropriately, and give em all profile pics. 
-
 - commands
     - use the built in "/" stuff.
     - i want a command for setting interval. beginning and end. 


### PR DESCRIPTION
Readme:
	Per the instructions in the readme there are now two prod bots and two
dev bots: Shitbot, Arbie, Shitbot Dev, and Arbie Dev

Makefile:
	Previously the `start` target would:
	1. run postgres AND migrations
	2. run migrations

The double running of migrations is unnecessary. I removed the first one 
and kept the second one so migrations explicitly run after postgres.

Added the removal of orphans and a network prune to the `nuke` command for 
more nukage.
