### PR TITLE
Sync Ballots between shitbot and ReadyBot Part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vs/
 .env
 node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ which is silly.
     - Admin
         - /something
 
+ballot+commannds use flow:
+- keep ballot message saved. dont send a new one on startup by default.
+- interval + score commands are ephemeral - you send them, they do stuff, they dont leave a message in chat. 
+
 - keep the ballots
     - one bot sends the ballot(S),
         - a particular reaction to a message from one bot can signal to the other that this is ballot 1 or two
@@ -347,7 +351,8 @@ tbd
     - :.,$s/pick/s
 - one nice explanation of what is happening in the squashed commit
 - format the width of the message to 80
-    - todo: put the vim command here
+    - :set textwidth=80
+    - gggqG
 - when you merge the pr, leave the name and body of the "merge" commit as default 
     - idea is the commit history will go 
         - "squashed commit with explanation of stuff"

--- a/discord/src/ballot-logic.ts
+++ b/discord/src/ballot-logic.ts
@@ -1,0 +1,37 @@
+import {
+  MessageReaction,
+  PartialMessageReaction,
+  PartialUser,
+  User,
+} from "discord.js";
+import {
+  mustGetEnv,
+  SHITBOT_USER_ID,
+  UTILITY_BALLOT_EMOJI,
+  VOTE_BALLOT_EMOJI,
+} from "./env.js";
+
+export async function detectBallots(
+  reaction: MessageReaction | PartialMessageReaction,
+  user: User | PartialUser,
+): Promise<void> {
+  // check if user is shitbot
+  if (user.id !== mustGetEnv(SHITBOT_USER_ID)) {
+    return;
+  }
+
+  // check if emoji is ballot1 or ballot2
+  let ballotType: string; // TODO(jruth): type this eventually
+  if (reaction.emoji.name === mustGetEnv(UTILITY_BALLOT_EMOJI)) {
+    ballotType = "utility";
+  } else if (reaction.emoji.name === mustGetEnv(VOTE_BALLOT_EMOJI)) {
+    ballotType = "vote";
+  } else {
+    return;
+  }
+
+  // TODO(jruth): this is where we plug in the call to the api to post the ballot to db
+  console.log(
+    `Detected ${ballotType} ballot with message ID ${reaction.message.id}`,
+  );
+}

--- a/discord/src/bot.ts
+++ b/discord/src/bot.ts
@@ -1,15 +1,22 @@
-import { Client, GatewayIntentBits, TextChannel } from "discord.js";
+import {
+  Client,
+  GatewayIntentBits,
+  Interaction,
+  TextChannel,
+} from "discord.js";
 import {
   handleCommand,
   registerCommands,
 } from "./command-logic/handle-commands.js";
-import { BOT_TOKEN, mustGetEnv } from "./env.js";
+import { BALLOT_CHANNEL_ID, BOT_TOKEN, mustGetEnv } from "./env.js";
+import { detectBallots } from "./ballot-logic.js";
 
 // make the client
 const client = new Client({
   intents: [
     GatewayIntentBits.Guilds, // see basic information about discord servers
     GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.GuildMessageReactions,
   ],
 });
 
@@ -19,15 +26,23 @@ client.once("clientReady", async () => {
   await registerCommands();
 
   // just send a poc message for now
-  let testChannel = "1399872069168009369"; // leaving this hardcoded for now,,, will fix as we leave poc stage
-  let channel = client.channels.cache.get(testChannel) as TextChannel;
+  let channel = client.channels.cache.get(
+    mustGetEnv(BALLOT_CHANNEL_ID),
+  ) as TextChannel;
   channel.send("ready!");
 });
 
 // Handle commands
-client.on("interactionCreate", async (interaction) => {
+client.on("interactionCreate", async (interaction: Interaction) => {
+  // only support / commands for now
   if (!interaction.isChatInputCommand()) return;
   await handleCommand(interaction);
 });
 
+// Handle reactions
+client.on("messageReactionAdd", async (reaction, user) => {
+  await detectBallots(reaction, user);
+});
+
+// let the games begin
 client.login(mustGetEnv(BOT_TOKEN));

--- a/discord/src/env.ts
+++ b/discord/src/env.ts
@@ -5,6 +5,10 @@ dotenv.config();
 export const BOT_TOKEN = "BOT_TOKEN";
 export const BOT_CLIENT_ID = "BOT_CLIENT_ID";
 export const GUILD_ID = "GUILD_ID";
+export const BALLOT_CHANNEL_ID = "BALLOT_CHANNEL_ID";
+export const UTILITY_BALLOT_EMOJI = "UTILITY_BALLOT_EMOJI";
+export const VOTE_BALLOT_EMOJI = "VOTE_BALLOT_EMOJI";
+export const SHITBOT_USER_ID = "SHITBOT_USER_ID";
 
 // retrieves an environment variable or throws an error if it is not set
 export function mustGetEnv(env: string): string {

--- a/discord/template.env
+++ b/discord/template.env
@@ -8,3 +8,14 @@ BOT_CLIENT_ID=
 
 # The guild in which arbie is running
 GUILD_ID=
+
+# The channel ID where ballots are posted
+BALLOT_CHANNEL_ID=
+
+# emoji that shitbot uses to mark a message as a utility/vote ballot, respectively.
+# shitbot has these hardcoded somewhere. 
+UTILITY_BALLOT_EMOJI=📓
+VOTE_BALLOT_EMOJI=📒
+
+# The user ID for shitbot... delete this asap
+SHITBOT_USER_ID=

--- a/shitbot/commands.js
+++ b/shitbot/commands.js
@@ -25,6 +25,7 @@ const sendBallots = async (bot, message, words) => {
     }
     try {
         bot.multiVoteMessage = await channel.send(message2Content)
+         bot.reactAll(["📒"], bot.multiVoteMessage)
         bot.reactAll(bot.getThemojis(), bot.multiVoteMessage)
     } catch (err) {
         throw new Error(`Vote message flow failed: ${err.message}`);

--- a/shitbot/main.js
+++ b/shitbot/main.js
@@ -66,7 +66,7 @@ var bot = {
     multiVoteMessage: null,                                 // the message which the user can react to for voting on themes/scores
     multiUtilityMessage: null,                              // the message which the user can react to for doing various utility operations (skip, back, order, shuffle)
     utilityEmojis:                                          // the emoji who perform actions for the utility message
-        ["⏮", "⬆", "⬇", "⏭", "🔼", "🔀", "🔽", "📅", "🆕", "🗑", "🥫", "❔", "📜"],
+              ["📓", "⏮", "⬆", "⬇", "⏭", "🔼", "🔀", "🔽", "📅", "🆕", "🗑", "🥫", "❔", "📜"],
     deletingEmoji: null,                                    // the emoji to be deleted (used to warn the user/prevent accidental deletion)
     deleteMessage: null,                                    // the message warning the user about their potential deletion
     deleteEmojis: ["✅", "❌"],                             // the emoji options for on the delete warning message
@@ -145,7 +145,10 @@ var bot = {
     // saves the mapping of themoji to playlistID to db
     saveToDB: async function () {
         console.log(`Saving themoji mappings to db`)
+        // wipe the whole table first
+        await this.query("DELETE FROM playlist_emojis;");
 
+        // then we're gonna stick everything into the table
         let queryMsg = "INSERT INTO playlist_emojis (emoji, spotify_playlist_id) VALUES "
 
         for (let i = 0; i < bot.multiThemes.length; i++) {
@@ -155,6 +158,7 @@ var bot = {
             }
         }
 
+   // dont really need this anymore but i fucking hate working in shitbot so. leaving this.
         queryMsg += `ON CONFLICT (emoji) DO UPDATE SET spotify_playlist_id = EXCLUDED.spotify_playlist_id;`
 
         try {
@@ -574,7 +578,10 @@ client.on('messageReactionAdd', (reaction, user) => {
         bot.actions.get(reaction.emoji.name)(bot)
     }
 
-    reaction.users.remove(user);
+    // remove the user's reaction 
+    reaction.users.remove(user).catch((error) => {
+        console.log("Error removing reaction: ", error)
+    })
     return
 });
 

--- a/template.env
+++ b/template.env
@@ -53,9 +53,6 @@ DISCORD_CONTROL_CHANNEL_ID=
 SPOTIFY_CLIENT_ID=
 SPOTIFY_CLIENT_SECRET=
 
-# My user id
-SPOTIFY_USER_ID=
-
 # shitbot stuff below...
 
 # location of the spotify refresh token - managed/refreshed by shitbot


### PR DESCRIPTION
This moves us one step closer to the death of shitbot.

this enables readybot and shitbot to share ballot messages. the way we do this
is that shitbot now adds an indicator emoji to the ballots as they are sent,
before any other emojis.
 - "📓" indicates that the message is the "Utility" message. the one with skip,
   shuffle, and upvote.
 - "📒" is reacted to the second ballot message, the "Vote" message. thats the
   one with all the themojis.

1. shitbot sends the ballots
2. shitbot reacts 📓 to the utility ballot, and 📒 to the vote ballot.
3. Readybot listens. When it hears 📓 reacted by shitbot, it knows that message
   is the utility ballot. likewise for 📒 and the vote ballot.
4. Then, Readybot will save those messages' ids to the db. this part is not yet
   implemented, because there is nowhere in the db to put that information, and
no api call to put that information there. but we have a todo in that spot
waiting for an api call to be possible/slotted in.

Notably, adding an emoji to the beginning of each message's reactions means that
the total amount of unique reactions on the message is increased by one. the
themojis are currently at max - this means we must delete one to make room for
the indicator emojis.

Fortunately, we have delete functionality already built into shitbot, so when we
deploy we can just use that... no. its fucking broken. so we fix the delete
functionality in this pr too, which involved TWO (2) broken components.

1. SaveToDB() would just take the list of themojis and insert them to the db.
   so, if your list of themojis was mysteriously missing any old themojis, and
you wanted to update the db to not have those missing themojis, that would just
not happen. they would stay in the db. so now we wipe the db before any saving
happens, and anything shitbot wants saved in the db is the only stuff that
exists in the db after the save.
 2. When you delete a themoji via the delete functionality, there is a
   confirmation message. when you confirm deletion, you react to the
confirmation message. when you react to confirm deletion, a race begins between
the removal of that emoji from the confirmation message and the deletion of that
confirmation message. if shitbot tries to remove the confirmation emoji from the
confirmation message after the message has been deleted, it errors. which is
fine. a good fix would stop the race from happening. a shitbot fix just logs the
error message.

Less notable things:
 - updated the readme with thoughts about ballots and the ballot channel and
   commands. read them if you want to know what they say.
 - moved the channel id to the .env
 - SPOTIFY_USER_ID is never used. bye bye.
 - gitignoring dist/ is a surprise tool that will help us later
