### PR TITLE
POST /ballots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ start:
 	docker compose up --build -d api postgres db-backups
 	$(MAKE) run-migrations
 	docker compose up --build -d shitbot discord
-	@echo "If you aren't seeing the ballot messages, consider going to http://localhost:8888/login to authenticate spotify."
+	@echo "If you aren't seeing the ballot messages, consider going to http://127.0.0.1:8888/login to authenticate spotify."
 
 # this will stop and wipe everything
 # -v will remove the volumes, which means the database will be wiped

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ its on discord only for like, a hyper lazy cross platform interface.
     - GET /scores
         - gets score values. we should do documentation
         - a test exists. more needed. very very wip.
+    - POST /ballots
+        - inserts information for a ballot message into the db.
+        - tests ✅
 - Will act as middleware between postgres and things that want access to postgres data
 - Will slowly port functionality over from the shitbot into this so that like, the discord bot does 90% on its own, and 10% via api, moving towards 0% shitbot and 100% api or whatever.
 - linting and prettying are supported/enforced
@@ -95,6 +98,7 @@ its on discord only for like, a hyper lazy cross platform interface.
     - docker will read var and start differently
     - use the appropriate vscode debugger launch config
     - profit
+- also, you can debug the unit tests. 
 
 ## Port conventions
 - Each service that gets a custom port shall increment up from the custom port of the previous service.

--- a/api/src/models/models.ts
+++ b/api/src/models/models.ts
@@ -8,3 +8,11 @@ export interface GetScoreResponse {
   totalScore: number; // Total score for the given URI and themoji across all time
   intervalScore: number; // Total score for the given URI and themoji within the specified interval
 }
+
+// dont think this really enforces anything, something something TODO(jruth): eventually zod maybe
+export type BallotType = 'utility' | 'vote';
+
+export interface PostBallotsRequestBody {
+  ballotType: BallotType; // Type of ballot being cast
+  messageID: string; // Message ID associated with the ballot
+}

--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -186,3 +186,157 @@ describe('GET /scores', () => {
     expect(res2.status).toBe(400);
   });
 });
+
+// test post ballots
+describe('POST /ballots', () => {
+  let tests = [
+    {
+      name: 'none supplied',
+      body: {},
+      expectedStatus: 400,
+      errorResponse: {
+        error: 'Missing body parameters',
+        missing: ['ballotType', 'messageID'],
+      },
+    },
+    {
+      name: 'only ballotType supplied',
+      body: { ballotType: 'utility' },
+      expectedStatus: 400,
+      errorResponse: {
+        error: 'Missing body parameters',
+        missing: ['messageID'],
+      },
+    },
+    {
+      name: 'only messageID supplied',
+      body: { messageID: '12345' },
+      expectedStatus: 400,
+      errorResponse: {
+        error: 'Missing body parameters',
+        missing: ['ballotType'],
+      },
+    },
+    {
+      name: 'invalid ballotType and invalid messageID',
+      body: { ballotType: 'invalid', messageID: '' },
+      expectedStatus: 400,
+      errorResponse: {
+        error: 'Invalid body parameters',
+        errors: [
+          "Invalid ballotType: 'invalid' (must be 'utility' or 'vote')",
+          "Invalid messageID: '' (must be a non-empty string)",
+        ],
+      },
+    },
+    {
+      name: 'invalid ballotType, valid messageID',
+      body: { ballotType: 'invalid', messageID: '12345' },
+      expectedStatus: 400,
+      errorResponse: {
+        error: 'Invalid body parameters',
+        errors: ["Invalid ballotType: 'invalid' (must be 'utility' or 'vote')"],
+      },
+    },
+    {
+      name: 'valid ballotType, invalid messageID',
+      body: { ballotType: 'utility', messageID: '' },
+      expectedStatus: 400,
+      errorResponse: {
+        error: 'Invalid body parameters',
+        errors: ["Invalid messageID: '' (must be a non-empty string)"],
+      },
+    },
+    {
+      name: 'valid ballotType and messageID, utility',
+      body: { ballotType: 'utility', messageID: 'utilitymessage1' },
+      expectedStatus: 204,
+      // check the db to make sure the message ID was set correctly
+      after: async () => {
+        const res = await pool.query(
+          `SELECT message_id FROM ballot_messages WHERE ballot_type = 'utility';`
+        );
+        expect(res.rows.length).toBe(1);
+        expect(res.rows[0].message_id).toBe('utilitymessage1');
+      },
+    },
+    {
+      name: 'valid ballotType and messageID, vote',
+      body: { ballotType: 'vote', messageID: 'votemessage1' },
+      expectedStatus: 204,
+      // check the db to make sure the message ID was set correctly
+      after: async () => {
+        const res = await pool.query(
+          `SELECT message_id FROM ballot_messages WHERE ballot_type = 'vote';`
+        );
+        expect(res.rows.length).toBe(1);
+        expect(res.rows[0].message_id).toBe('votemessage1');
+      },
+    },
+    {
+      name: 'confirm duplicate utility inserts do not error',
+      body: { ballotType: 'utility', messageID: 'utilitymessage1' },
+      expectedStatus: 204,
+      // check the db to make sure the value is still correct
+      after: async () => {
+        const res = await pool.query(
+          `SELECT message_id FROM ballot_messages WHERE ballot_type = 'utility';`
+        );
+        expect(res.rows.length).toBe(1);
+        expect(res.rows[0].message_id).toBe('utilitymessage1');
+      },
+    },
+    {
+      name: 'confirm duplicate vote inserts do not error',
+      body: { ballotType: 'vote', messageID: 'votemessage1' },
+      expectedStatus: 204,
+      // check the db to make sure the value is still correct
+      after: async () => {
+        const res = await pool.query(
+          `SELECT message_id FROM ballot_messages WHERE ballot_type = 'vote';`
+        );
+        expect(res.rows.length).toBe(1);
+        expect(res.rows[0].message_id).toBe('votemessage1');
+      },
+    },
+    {
+      name: 'confirm sequential utility inserts overwrite previous values',
+      body: { ballotType: 'utility', messageID: 'utilitymessage2' },
+      expectedStatus: 204,
+      // check the db to make sure the value is updated correctly
+      after: async () => {
+        const res = await pool.query(
+          `SELECT message_id FROM ballot_messages WHERE ballot_type = 'utility';`
+        );
+        expect(res.rows.length).toBe(1);
+        expect(res.rows[0].message_id).toBe('utilitymessage2');
+      },
+    },
+    {
+      name: 'confirm sequential vote inserts overwrite previous values',
+      body: { ballotType: 'vote', messageID: 'votemessage2' },
+      expectedStatus: 204,
+      // check the db to make sure the value is updated correctly
+      after: async () => {
+        const res = await pool.query(
+          `SELECT message_id FROM ballot_messages WHERE ballot_type = 'vote';`
+        );
+        expect(res.rows.length).toBe(1);
+        expect(res.rows[0].message_id).toBe('votemessage2');
+      },
+    },
+  ];
+
+  tests.forEach((test) => {
+    it(test.name, async () => {
+      const res = await request(server).post('/ballots').send(test.body);
+      expect(res.status).toBe(test.expectedStatus);
+      if (test.errorResponse) {
+        expect(res.body).toEqual(test.errorResponse);
+      }
+      if (test.after) {
+        await test.after();
+      }
+    });
+  });
+});

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,10 +1,15 @@
 import express, { Request, Response } from 'express';
 import { Pool } from 'pg';
-import { GetScoreRequestParams, GetScoreResponse } from './models/models';
+import {
+  GetScoreRequestParams,
+  GetScoreResponse,
+  PostBallotsRequestBody,
+} from './models/models';
 
 // TODO(jruth): add types to the returned stuff
 export function createServer() {
   const server = express();
+  server.use(express.json());
 
   // this is the postgres client
   // TODO(jruth): close this somewhere...
@@ -88,6 +93,78 @@ export function createServer() {
 
       // send response
       res.json(response);
+    }
+  );
+
+  // post /ballots
+  // update the messageID for a particular ballot type (utility or vote) in the db
+  // this is gonna be called by the discord bot when it sees that shitbot posted a new ballot message
+  // ballotType must be either "utility" or "vote"
+  // messageID must be a non-empty string, because I can't think of any good reason to allow an empty messageID.
+  server.post(
+    '/ballots',
+    async (
+      req: Request<unknown, unknown, PostBallotsRequestBody, unknown>,
+      res: Response
+    ) => {
+      // handle missing parameters
+      if (
+        req.body.ballotType === undefined ||
+        req.body.messageID === undefined
+      ) {
+        const missing = [];
+        if (!req.body.ballotType) missing.push('ballotType');
+        if (!req.body.messageID) missing.push('messageID');
+
+        res.status(400).json({
+          error: 'Missing body parameters',
+          missing,
+        });
+        return;
+      }
+
+      // check if ballotType is valid
+      let ballotTypeValid: boolean =
+        req.body.ballotType === 'utility' || req.body.ballotType === 'vote';
+
+      // check if messageID is valid
+      let messageIDValid: boolean = req.body.messageID !== '';
+
+      // handle invalid parameters
+      if (!ballotTypeValid || !messageIDValid) {
+        const errors = [];
+        if (!ballotTypeValid)
+          errors.push(
+            `Invalid ballotType: '${req.body.ballotType}' (must be 'utility' or 'vote')`
+          );
+        if (!messageIDValid)
+          errors.push(
+            `Invalid messageID: '${req.body.messageID}' (must be a non-empty string)`
+          );
+
+        res.status(400).json({
+          error: 'Invalid body parameters',
+          errors,
+        });
+        return;
+      }
+
+      // if we get here then we're good to go...
+
+      // the query to set the message ID for the ballot type
+      const query = `UPDATE ballot_messages SET message_id = $1 WHERE ballot_type = $2;`;
+
+      // query the db
+      try {
+        await pool.query(query, [req.body.messageID, req.body.ballotType]);
+      } catch (e) {
+        console.error('Database query error:', e);
+        res.status(500).json({ error: 'Internal server error' });
+        return;
+      }
+
+      // send response
+      res.sendStatus(204); // no content
     }
   );
 

--- a/bruno/ReadyBot/Hello World.bru
+++ b/bruno/ReadyBot/Hello World.bru
@@ -1,5 +1,5 @@
 meta {
-  name: hello world
+  name: Hello World
   type: http
   seq: 1
 }

--- a/bruno/ReadyBot/Post Ballots.bru
+++ b/bruno/ReadyBot/Post Ballots.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Post Ballots
+  type: http
+  seq: 4
+}
+
+post {
+  url: http://localhost:{{API_PORT}}/ballots
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "ballotType": "vote", 
+    "messageID": "1474542408611139634"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     env_file:
       - .env
     ports:
-      - "8888:8888" # for spotify web login (http://localhost:8888/login)
+      - "8888:8888" # for spotify web login (http://127.0.0.1:8888/login)
     volumes:
       - shitbotdata:/data # persist the spotify refresh token file (and nothing else)
   discord:

--- a/goals.txt
+++ b/goals.txt
@@ -1,1 +1,3 @@
 update the readme (this goal should be in every goals.txt...)
+
+future work: api tests for all endpoints should not all be in the same folder, same for endpoints being defined in server.ts 

--- a/migrations/migrations/20260220211641_ballot_info.sql
+++ b/migrations/migrations/20260220211641_ballot_info.sql
@@ -1,0 +1,19 @@
+-- migrate:up
+
+-- This table stores the message IDs for the ballots.
+-- ballot_type is the primary key, ensuring that there is only one message ID per ballot type.
+-- ballot_type can only be either 'utility' or 'vote'.
+CREATE TABLE ballot_messages (
+  ballot_type TEXT PRIMARY KEY,
+  message_id  TEXT,
+  CHECK (ballot_type IN ('utility', 'vote'))
+);
+
+INSERT INTO ballot_messages (ballot_type, message_id)
+VALUES
+  ('utility', null),
+  ('vote',    null);
+
+-- migrate:down
+
+DROP TABLE IF EXISTS ballot_messages;

--- a/shitbot/main.js
+++ b/shitbot/main.js
@@ -51,7 +51,7 @@ var bot = {
     spotifyApi: new SpotifyWebApi({
         clientId: process.env.SPOTIFY_CLIENT_ID,
         clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
-        redirectUri: 'http://localhost:8888/callback'
+        redirectUri: 'http://127.0.0.1:8888/callback'
     }),
     spotifyUserID: process.env.SPOTIFY_USER_ID,             //my user id
 
@@ -727,7 +727,7 @@ app.get('/callback', (req, res) => {
 
 app.listen(8888, () =>
     console.log(
-        'HTTP Server up, http://localhost:8888/login is now available.'
+        'HTTP Server up, http://127.0.0.1:8888/login is now available.'
     )
 );
 client.login(bot.tokenDiscord);
@@ -782,7 +782,7 @@ let kickOffTokenRefresh = () => {
 
     // worst case - no tokens available. Login needed.
     else {
-        console.log("No refresh token found. Go to https://localhost:8888/login to login")
+        console.log("No refresh token found. Go to https://127.0.0.1:8888/login to login")
         return
     }
 


### PR DESCRIPTION
Now there is:
 - a place in the db to store ballot message information
 - and an endpoint that lets you shove that information into there.

THE PLACE WHERE WE STORE THE BALLOT MESSAGE INFORMATION...
so, we want a place to store the message id for the first ballot (the utility ballot) and the message id for the second ballot (the vote ballot).
accordingly, there is now a table called `ballot_messages`, with two TEXT columns `ballot_type` and `message_id`.
`ballot_type` is the primary key so that there is only ever one messageID stored for each type, and there is a check that enforces that `ballot_type` must be either `utility` or `vote`. 

this means that the table can only ever store two total messageIDs: one for the utility ballot, and one for the vote ballot. which is convenient, because that is exactly what we want to put in there. 

THE THING THAT LETS YOU SHOVE THE BALLOT INFORMATION INTO THE DB...
there's an endpoint: POST /ballots
requests to this endpoint must have a body with the following fields:
ballotType - must be either "utility" or "vote" exactly
messageID - must be a non-empty string. 
	- "Why non-empty? What if I want it to be empty?"
	- If we ever want to set a messageID to be empty, we're saying that no ballot message exists. if that happens, we're just fucked because shitbot's `\ballots` command is broken and so theres no way to get the ballots to come back. So basically, if we ever want to set the messageID to "", then there are much larger problems to worry about than "but i wanna set it to empty". so its banned.

if the params are both valid, then they will get stuffed into the db. otherwise they wont. cool

the endpoint has tests! they run. they pass. so good. 


Notable mentions:
 - the BallotType type in model.ts is currently unused, but exists to be built upon/used when we make the client/use the client. or something. tbd. 
 - added a bruno guy for the new endpoint
 - for spotify auth apparently april 2025 spotify changed it so using localhost isnt allowed to work anymore and you have to do this newfangled 127.0.0.1 thing nowadays instead. i think we got away with not having to change this all this time because we've been using the refresh token.