### PR TITLE
Empty Golang API Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,42 @@ rclone config
 cp ~/.config/rclone/rclone.conf ./db-backups/rclone/rclone.conf
 ```
 
-### 5. Bruno stuff.
+### 5. Install Golang
+
+```
+# find latest
+GOTAR=$(wget -qO- 'https://go.dev/dl/?mode=json' | grep -o 'go[0-9.]*linux-amd64.tar.gz' | head -1)
+rm index.html
+
+# download
+wget https://go.dev/dl/$GOTAR
+
+# extract
+sudo tar -C /usr/local -xzf $GOTAR
+
+# add to PATH
+echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
+source ~/.bashrc
+
+# verify
+go version
+```
+
+### 5.1 Are you using zsh? If so, do this
+
+```
+# add to zshrc instead so it persists in zsh
+echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.zshrc
+source ~/.zshrc
+
+# delete the tarball since you don't need it anymore
+rm $GOTAR
+
+# verify
+go version
+```
+
+### N. Bruno stuff.
 
 ```
 todo (include link to download)

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,27 @@
+# Use an official Golang image for putting the Go binary together
+FROM golang:1.26-alpine AS builder
+
+# Set working dir
+WORKDIR /app
+
+# Copy go.mod (and go.sum later) and install dependencies
+COPY go.mod ./
+RUN go mod download
+
+# Copy the rest of the code
+COPY . .
+
+# Compile it to a binary named "server"
+RUN go build -o server .
+
+# Use a smaller image for the final container
+FROM alpine:latest
+
+# Set the working dir for the final container
+WORKDIR /root/
+
+# Copy the binary over from the builder stage
+COPY --from=builder /app/server .
+
+# Set the entrypoint to the server executable
+CMD ["./server"]

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,0 +1,3 @@
+module readybot/api
+
+go 1.26.2

--- a/api/main.go
+++ b/api/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello World")
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,15 @@
 services:
-  # api: commented out as first steps away from ts and towards golang
-  #   build:
-  #     context: ./api
-  #   restart: always
-  #   env_file:
-  #     - ./api/.env
-  #     - .env
-  #   ports:
-  #     - "${API_PORT}:${API_PORT}"
-  #     - "${API_DEBUG_PORT}:${API_DEBUG_PORT}"
+  api: 
+    build:
+      context: ./api
+    # commented while migrating to golang. uncomment as necessary. 
+    # restart: always 
+    # env_file:
+    #   - ./api/.env
+    #   - .env
+    # ports:
+    #   - "${API_PORT}:${API_PORT}"
+    #   - "${API_DEBUG_PORT}:${API_DEBUG_PORT}"
   postgres:
     build:
       context: ./db

--- a/goals.txt
+++ b/goals.txt
@@ -17,7 +17,9 @@ tests
 
 cicd
 
-i say lets just turn off the ts api but keep the code ✅
+
+do empty golang service ✅
+- just a main.go which like. logs hello world. and then dies. ✅
 
 build new service to replace
 - does a golang api
@@ -25,7 +27,6 @@ build new service to replace
 - get a basic/empty golang api service hello world that just prints hello world and doesnt do api server yet
 - then build server on top of that
 
-list endpoints ✅
 existing ts endpoints:
     - GET /hello - responds "hello world" or something
         - migrate to golang
@@ -37,7 +38,6 @@ existing ts endpoints:
         - migrate to golang
         - migrate test
 
-think about cicd ✅
 - what does it do and what is in it
     - starts postgres db up and going
     - runs test file
@@ -50,10 +50,24 @@ think about cicd ✅
     - new test file/framework (some golang test thing)
     - that starts a golang api (todo) and runs tests against that
 
-rename current api to api-ts? no
-- just move contents to new folder api-ts ✅
-- new stuff goes in new api folder
-- cicd just comment out for now ✅
-
 make sure to update precommit/linter stuff to not care about api anymore
 - makefile too probs
+
+
+# we should upgrade the raspi. 
+
+```
+➜  ReadyBot git:(main) dpkg --print-architecture
+armhf
+➜  ReadyBot git:(main) uname -m
+cat /etc/os-release | grep PRETTY_NAME
+aarch64
+PRETTY_NAME="Raspbian GNU/Linux 11 (bullseye)"
+```
+
+we can make it better. 
+- gotta save all the configs
+    - .env
+    - rclone
+- flash it
+- and then redeploy


### PR DESCRIPTION
This sets up an empty API service which just uses Golang to print Hello World.

Will be built upon in the future.

Notably, there remains a question of how we will install golang on the raspi. we can do it programmatically as in the setup instructions, but... the raspi is in a weird position architecture wise. See below. Basically, we can jank it and get this merged, or we can upgrade the raspi and get this done not-jank. The jank would just be the setup of golang, but these things add up. 

I propose we bite the bullet and upgrade the raspi. More to read about that in goals.txt

```
➜  ReadyBot git:(main) dpkg --print-architecture
armhf
➜  ReadyBot git:(main) uname -m
cat /etc/os-release | grep PRETTY_NAME
aarch64
PRETTY_NAME="Raspbian GNU/Linux 11 (bullseye)"
```